### PR TITLE
runtime: Add SIMD-0418 feature gate

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1220,6 +1220,10 @@ pub mod bls_pubkey_management_in_vote_account {
     solana_pubkey::declare_id!("EGJLweNUVskAPEwpjvNB7JT6uUi6h4mFhowNYXVSrimG");
 }
 
+pub mod enable_loader_v2_to_v3_program_migrations {
+    solana_pubkey::declare_id!("migrx8TrcuwS3E4eQxi3ECpNGWXz5o85cXZu4WqJXsu");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2186,6 +2190,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             bls_pubkey_management_in_vote_account::id(),
             "SIMD-0387: BLS Pubkey Management in Vote Account",
+        ),
+        (
+            enable_loader_v2_to_v3_program_migrations::id(),
+            "SIMD-0418: Enable Loader v2 to v3 Program Migrations",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,8 +60,8 @@ use {
     },
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     agave_feature_set::{
-        self as feature_set, increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8,
-        FeatureSet,
+        self as feature_set, enable_loader_v2_to_v3_program_migrations,
+        increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8, FeatureSet,
     },
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
@@ -5440,6 +5440,8 @@ impl Bank {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(
                 &feature_set::replace_spl_token_with_p_token::SPL_TOKEN_PROGRAM_ID,
                 &feature_set::replace_spl_token_with_p_token::PTOKEN_PROGRAM_BUFFER,
+                self.feature_set
+                    .is_active(&enable_loader_v2_to_v3_program_migrations::id()),
                 "replace_spl_token_with_p_token",
             ) {
                 warn!(
@@ -5474,9 +5476,12 @@ impl Bank {
                 // activation, perform the migration which will remove it from
                 // the builtins list and the cache.
                 if new_feature_activations.contains(&core_bpf_migration_config.feature_id) {
-                    if let Err(e) = self
-                        .migrate_builtin_to_core_bpf(&builtin.program_id, core_bpf_migration_config)
-                    {
+                    if let Err(e) = self.migrate_builtin_to_core_bpf(
+                        &builtin.program_id,
+                        core_bpf_migration_config,
+                        self.feature_set
+                            .is_active(&enable_loader_v2_to_v3_program_migrations::id()),
+                    ) {
                         warn!(
                             "Failed to migrate builtin {} to Core BPF: {}",
                             builtin.name, e
@@ -5495,6 +5500,8 @@ impl Bank {
                     if let Err(e) = self.migrate_builtin_to_core_bpf(
                         &stateless_builtin.program_id,
                         core_bpf_migration_config,
+                        self.feature_set
+                            .is_active(&enable_loader_v2_to_v3_program_migrations::id()),
                     ) {
                         warn!(
                             "Failed to migrate stateless builtin {} to Core BPF: {}",


### PR DESCRIPTION
#### Problem

SIMD-0418 enables Loader v2 to v3 program migrations when the target program data accounts is already funded, which currently it is not possible.

#### Summary of Changes

This PR adds a feature for SIMD-0418 and updates the migration validation to allow pre-funded program data accounts.